### PR TITLE
Expanding functionality with meta information from the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@ Response:
 }
 
     curl -d '{"url":"https://www.alza.cz/aeg-7000-prosteam-lfr73964cc-d7635493.htm","fields":{"price":".price-box__price","rating_count":".ratingCount","rating_value":".ratingValue"}}' -H "Content-Type: application/json" -X GET http://localhost:3000/data
+
+### Task #2
+
+Expanding functionality with meta information from the page. As part of the request, add "meta" to the fields where the array contains the "name" of individual meta tags.
+
+Request:
+
+{"url":"https://www.alza.cz/aeg-7000-prosteam-lfr73964cc-d7635493.htm","fields":{"meta":["keywords","twitter:image"]}}
+
+Response:
+
+{"meta":{"keywords":"Parní pračka AEG 7000 ProSteam® LFR73964CC na www.alza.cz. Bezpečný nákup. Veškeré informace o produktu. Vhodné příslušenství Hodnocení a recenze AEG...", "twitter:image":"https"://image.alza.cz/products/AEGPR065/AEGPR065.jpg?width=360&height=360"}}
+
+    curl -d '{"url":"https://www.alza.cz/aeg-7000-prosteam-lfr73964cc-d7635493.htm","fields":{"meta":["keywords","twitter:image"]}}' -H "Content-Type: application/json" -X GET http://localhost:3000/data

--- a/app/controllers/scraper_controller.rb
+++ b/app/controllers/scraper_controller.rb
@@ -21,7 +21,16 @@ class ScraperController < ApplicationController
     body = Nokogiri::HTML.parse(driver.page_source)
 
     fields.each do |field_name, selector|
-      scraped_data[field_name] = body.css(selector).text.strip
+      if field_name == 'meta'
+        meta_data = {}
+        selector.each do |meta_name|
+          meta_tag = body.css("meta[name='#{meta_name}']").first
+          meta_data[meta_name] = meta_tag['content'] if meta_tag
+        end
+        scraped_data['meta'] = meta_data
+      else
+        scraped_data[field_name] = body.css(selector).text.strip
+      end
     end
 
     render json: scraped_data

--- a/spec/controllers/scraper_controller_spec.rb
+++ b/spec/controllers/scraper_controller_spec.rb
@@ -6,13 +6,16 @@ RSpec.describe ScraperController, type: :controller do
   describe 'GET #scrape' do
     let(:url) { 'https://example.com' }
     let(:fields) { { 'title' => 'h1' } }
+    let(:meta) { { 'meta' => ['keywords'] } }
     let(:html) { '<html><body><h1>Title</h1><p>Content</p></body></html>' }
+    let(:meta_html) { '<html><head><meta name="keywords" content="keyword"</head></html>' }
     let(:invalid_params) { { url: '', fields: {} } }
 
-    context 'with valid parameters' do
+    context 'with valid fields parameters' do
       before do
         allow_any_instance_of(Selenium::WebDriver::Driver).to receive(:page_source).and_return(html)
         allow(Nokogiri::HTML).to receive(:parse).with(html).and_return(Nokogiri::HTML(html))
+        allow_any_instance_of(Nokogiri::HTML::Document).to receive(:css).and_call_original
         allow_any_instance_of(Nokogiri::HTML::Document).to receive(:css).with('h1').and_return(Nokogiri::HTML(html).css('h1'))
       end
 
@@ -20,6 +23,21 @@ RSpec.describe ScraperController, type: :controller do
         get :scrape, params: { url:, fields: }
         expect(response).to have_http_status(:success)
         expect(JSON.parse(response.body)).to eq({ 'title' => 'Title' })
+      end
+    end
+
+    context 'with valid meta parameters' do
+      before do
+        allow_any_instance_of(Selenium::WebDriver::Driver).to receive(:page_source).and_return(meta_html)
+        allow(Nokogiri::HTML).to receive(:parse).with(meta_html).and_return(Nokogiri::HTML(meta_html))
+        allow_any_instance_of(Nokogiri::HTML::Document).to receive(:css).and_call_original
+        allow_any_instance_of(Nokogiri::HTML::Document).to receive(:css).with('meta[name=keywords]').and_return(Nokogiri::HTML(meta_html).css('meta[name=keywords]'))
+      end
+
+      it 'returns scraped data' do
+        get :scrape, params: { url: url, fields: meta }
+        expect(response).to have_http_status(:success)
+        expect(JSON.parse(response.body)).to eq({ "meta" => {"keywords" => "keyword"} })
       end
     end
 


### PR DESCRIPTION
Expanding functionality with meta information from the page. As part of the request, add
"meta" to the fields where the array contains the "name" of individual meta tags.